### PR TITLE
Fix silent flutter_tools hang during git background fetches

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -328,9 +328,10 @@ class UpgradeCommandRunner {
   Future<FlutterVersion> fetchLatestVersion({required FlutterVersion localVersion}) async {
     String revision;
     try {
-      // Fetch upstream branch's commits and tags
+      // Fetch upstream branch's commits and tags.
+      // Use BatchMode to prevent ssh-agent hanging in the background.
       await globals.git.run(
-        ['fetch', '--tags'],
+        ['-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags'],
         throwOnError: true,
         workingDirectory: workingDirectory,
       );

--- a/packages/flutter_tools/lib/src/git.dart
+++ b/packages/flutter_tools/lib/src/git.dart
@@ -60,7 +60,11 @@ interface class Git {
       allowedFailures: allowedFailures,
       workingDirectory: workingDirectory,
       allowReentrantFlutter: allowReentrantFlutter,
-      environment: {if (_platform.isWindows) ..._useNoGlobCygwinGit, ...?environment},
+      environment: {
+        ..._noPromptEnvironment,
+        if (_platform.isWindows) ..._useNoGlobCygwinGit,
+        ...?environment,
+      },
       timeout: timeout,
       timeoutRetries: timeoutRetries,
     );
@@ -90,7 +94,11 @@ interface class Git {
       allowedFailures: allowedFailures,
       hideStdout: hideStdout,
       workingDirectory: workingDirectory,
-      environment: {if (_platform.isWindows) ..._useNoGlobCygwinGit, ...?environment},
+      environment: {
+        ..._noPromptEnvironment,
+        if (_platform.isWindows) ..._useNoGlobCygwinGit,
+        ...?environment,
+      },
       allowReentrantFlutter: allowReentrantFlutter,
       encoding: encoding,
     );
@@ -128,4 +136,11 @@ interface class Git {
   }
 
   static const _useNoGlobCygwinGit = {'MSYS': 'noglob', 'CYGWIN': 'noglob'};
+
+  /// Environment variables to ensure that background Git operations fail fast rather than
+  /// hanging if they require user interaction (e.g. asking for SSH passphrases).
+  /// See: https://github.com/flutter/flutter/issues/184309
+  static const _noPromptEnvironment = <String, String>{
+    'GIT_TERMINAL_PROMPT': '0',
+  };
 }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -391,8 +391,9 @@ abstract class FlutterVersion {
   /// remote git repository is not reachable due to a network issue.
   Future<String> _fetchRemoteFrameworkCommitDate() async {
     try {
-      // Fetch upstream branch's commit and tags
-      await _run(_git, ['fetch', '--tags']);
+      // Fetch upstream branch's commit and tags.
+      // Use BatchMode to prevent ssh-agent hanging in the background.
+      await _run(_git, ['-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags']);
       return _gitCommitDate(
         git: _git,
         gitRef: kGitTrackingUpstream,
@@ -1021,7 +1022,11 @@ class GitTagVersion {
       } else {
         final String flutterGit =
             platform.environment['FLUTTER_GIT_URL'] ?? 'https://github.com/flutter/flutter.git';
-        git.runSync(['fetch', flutterGit, '--tags', '-f'], workingDirectory: workingDirectory);
+        // Use BatchMode to prevent ssh-agent hanging in the background.
+        git.runSync(
+          ['-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', flutterGit, '--tags', '-f'],
+          workingDirectory: workingDirectory,
+        );
       }
     }
     // find all tags attached to the given [gitRef]. These are returned in alphabetical order, so

--- a/packages/flutter_tools/test/commands.shard/hermetic/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/upgrade_test.dart
@@ -67,7 +67,7 @@ void main() {
           stdout: startingTag,
         ),
         // Ensure we have upstream tags present locally
-        const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+        const FakeCommand(command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags']),
         const FakeCommand(
           command: <String>['git', 'rev-parse', '--verify', '@{upstream}'],
           stdout: upstreamHeadRevision,
@@ -152,7 +152,7 @@ void main() {
           command: <String>['git', 'tag', '--points-at', 'HEAD'],
           stdout: startingTag,
         ),
-        const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+        const FakeCommand(command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags']),
         const FakeCommand(
           command: <String>['git', 'rev-parse', '--verify', '@{upstream}'],
           stdout: upstreamHeadRevision,
@@ -244,7 +244,7 @@ void main() {
           workingDirectory: flutterRoot,
         ),
         const FakeCommand(
-          command: <String>['git', 'fetch', '--tags'],
+          command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags'],
           workingDirectory: flutterRoot,
         ),
         const FakeCommand(

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -286,7 +286,7 @@ void main() {
         const version = '1.2.3';
 
         processManager.addCommands(<FakeCommand>[
-          const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+          const FakeCommand(command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags']),
           const FakeCommand(
             command: <String>['git', 'rev-parse', '--verify', '@{upstream}'],
             stdout: revision,
@@ -319,7 +319,7 @@ void main() {
         const revision = 'abc123';
 
         processManager.addCommands(<FakeCommand>[
-          const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+          const FakeCommand(command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags']),
           const FakeCommand(
             command: <String>['git', 'rev-parse', '--verify', '@{upstream}'],
             stdout: revision,
@@ -348,7 +348,7 @@ void main() {
       'fetchLatestVersion throws toolExit if HEAD is detached',
       () async {
         processManager.addCommands(const <FakeCommand>[
-          FakeCommand(command: <String>['git', 'fetch', '--tags']),
+          FakeCommand(command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags']),
           FakeCommand(
             command: <String>['git', 'rev-parse', '--verify', '@{upstream}'],
             exception: ProcessException('git', <String>[
@@ -381,7 +381,7 @@ void main() {
       'fetchLatestVersion throws toolExit if no upstream configured',
       () async {
         processManager.addCommands(const <FakeCommand>[
-          FakeCommand(command: <String>['git', 'fetch', '--tags']),
+          FakeCommand(command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags']),
           FakeCommand(
             command: <String>['git', 'rev-parse', '--verify', '@{upstream}'],
             exception: ProcessException('git', <String>[

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -167,7 +167,7 @@ void main() {
               ],
               stdout: getChannelUpToDateVersion().toString(),
             ),
-            const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+            const FakeCommand(command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags']),
             FakeCommand(
               command: const <String>[
                 'git',
@@ -367,7 +367,7 @@ void main() {
               ],
               stdout: getChannelUpToDateVersion().toString(),
             ),
-            const FakeCommand(command: <String>['git', 'fetch', '--tags']),
+            const FakeCommand(command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', '--tags']),
             FakeCommand(
               command: const <String>[
                 'git',
@@ -1483,7 +1483,7 @@ void main() {
         stdout: 'master',
       ),
       const FakeCommand(
-        command: <String>['git', 'fetch', 'https://github.com/flutter/flutter.git', '--tags', '-f'],
+        command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', 'https://github.com/flutter/flutter.git', '--tags', '-f'],
       ),
       const FakeCommand(command: <String>['git', 'tag', '--points-at', 'HEAD']),
       ...mockGitTagHistory(
@@ -1506,7 +1506,7 @@ void main() {
         stdout: 'master',
       ),
       const FakeCommand(
-        command: <String>['git', 'fetch', 'https://githubmirror.com/flutter.git', '--tags', '-f'],
+        command: <String>['git', '-c', 'core.sshCommand=ssh -o BatchMode=yes', 'fetch', 'https://githubmirror.com/flutter.git', '--tags', '-f'],
       ),
       const FakeCommand(command: <String>['git', 'tag', '--points-at', 'HEAD']),
       ...mockGitTagHistory(


### PR DESCRIPTION
Fixes an issue where `flutter_tools` would silently hang when git background operations block on SSH password prompts. This is done by enforcing `BatchMode=yes` during fetch operations.

---
*PR created automatically by Jules for task [8939177479079620407](https://jules.google.com/task/8939177479079620407) started by @bkonyi*